### PR TITLE
Fix pop model_name

### DIFF
--- a/src/funcchain/model/defaults.py
+++ b/src/funcchain/model/defaults.py
@@ -155,7 +155,7 @@ def univeral_model_selector(
         except Exception as e:
             print(e)
 
-    model_kwargs.pop("model_name")
+    model_kwargs.pop("model_name", None)
 
     if settings.openai_api_key:
         from langchain_openai.chat_models import ChatOpenAI


### PR DESCRIPTION
I'm encountering an error where model_name is not in model_kwargs, if `llm` is not a string.

```python
default_handler
    return chain(settings_override=settings_override)
  File "/Users/ahuang/miniconda3/envs/funcchain/lib/python3.10/site-packages/funcchain/syntax/executable.py", line 61, in chain
    chain: Runnable[dict[str, Any], Any] = compile_chain(sig, temp_images)
  File "/Users/ahuang/miniconda3/envs/funcchain/lib/python3.10/site-packages/funcchain/backend/compiler.py", line 209, in compile_chain
    return create_chain(
  File "/Users/ahuang/miniconda3/envs/funcchain/lib/python3.10/site-packages/funcchain/backend/compiler.py", line 102, in create_chain
    _llm = _gather_llm(settings)
  File "/Users/ahuang/miniconda3/envs/funcchain/lib/python3.10/site-packages/funcchain/backend/compiler.py", line 336, in _gather_llm
    llm = univeral_model_selector(settings)
  File "/Users/ahuang/miniconda3/envs/funcchain/lib/python3.10/site-packages/funcchain/model/defaults.py", line 158, in univeral_model_selector
    model_kwargs.pop("model_name")
KeyError: 'model_name'
```